### PR TITLE
Use the dash to underscore fix for endpoints only when calling method

### DIFF
--- a/class-base-api.php
+++ b/class-base-api.php
@@ -142,6 +142,8 @@ abstract class Base_API {
 
 		$endpoint = array_shift( $api );
 
+		$endpoint_method = str_replace( '-', '_', $endpoint );
+
 		$is_front_endpoint = false;
 		$is_admin_endpoint = false;
 
@@ -153,15 +155,13 @@ abstract class Base_API {
 			$is_admin_endpoint = true;
 		}
 
-		if ( ( ! $is_front_endpoint && ! $is_admin_endpoint ) || ! method_exists( $this, $endpoint ) ) {
+		if ( ( ! $is_front_endpoint && ! $is_admin_endpoint ) || ! method_exists( $this, $endpoint_method ) ) {
 			wp_send_json_error( __( 'This endpoint does not exist.', 'base-api' ) );
 		}
 
 		if ( $is_admin_endpoint && ! $this->is_user_admin() ) {
 			wp_send_json_error( __( 'This is an admin-only endpoint.', 'base-api' ) );
 		}
-
-		$endpoint_method = str_replace( '-', '_', $endpoint );
 
 		$data = call_user_func_array( array( $this, $endpoint_method ), $api );
 

--- a/class-base-api.php
+++ b/class-base-api.php
@@ -141,7 +141,6 @@ abstract class Base_API {
 		$api = explode( '/', $wp_query->query_vars[ static::$rewrite_endpoint ] );
 
 		$endpoint = array_shift( $api );
-		$endpoint = str_replace( '-', '_', $endpoint );
 
 		$is_front_endpoint = false;
 		$is_admin_endpoint = false;
@@ -162,7 +161,9 @@ abstract class Base_API {
 			wp_send_json_error( __( 'This is an admin-only endpoint.', 'base-api' ) );
 		}
 
-		$data = call_user_func_array( array( $this, $endpoint ), $api );
+		$endpoint_method = str_replace( '-', '_', $endpoint );
+
+		$data = call_user_func_array( array( $this, $endpoint_method ), $api );
 
 		// Check for WP_Error response
 		if ( is_wp_error( $data ) ) {


### PR DESCRIPTION
Allows endpoints to be strictly defined with dashes as allowed in front/admin endpoint arrays
